### PR TITLE
Simplify compute test env

### DIFF
--- a/cpp/src/arrow/acero/aggregate_node_test.cc
+++ b/cpp/src/arrow/acero/aggregate_node_test.cc
@@ -34,12 +34,7 @@
 
 namespace arrow {
 
-using compute::ComputeKernelEnvironment;
 using compute::ExecBatchFromJSON;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 namespace acero {
 

--- a/cpp/src/arrow/acero/aggregate_node_test.cc
+++ b/cpp/src/arrow/acero/aggregate_node_test.cc
@@ -24,7 +24,6 @@
 
 #include "arrow/acero/test_util_internal.h"
 #include "arrow/compute/api_aggregate.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/compute/test_util_internal.h"
 #include "arrow/result.h"
 #include "arrow/table.h"

--- a/cpp/src/arrow/acero/asof_join_node_test.cc
+++ b/cpp/src/arrow/acero/asof_join_node_test.cc
@@ -70,15 +70,10 @@ using testing::UnorderedElementsAreArray;
 namespace arrow {
 
 using compute::Cast;
-using compute::ComputeKernelEnvironment;
 using compute::Divide;
 using compute::ExecBatchFromJSON;
 using compute::Multiply;
 using compute::Subtract;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 namespace acero {
 

--- a/cpp/src/arrow/acero/asof_join_node_test.cc
+++ b/cpp/src/arrow/acero/asof_join_node_test.cc
@@ -42,7 +42,6 @@
 #include "arrow/api.h"
 #include "arrow/compute/api_scalar.h"
 #include "arrow/compute/cast.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/compute/row/row_encoder_internal.h"
 #include "arrow/compute/test_util_internal.h"
 #include "arrow/testing/generator.h"

--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -39,7 +39,6 @@
 #include "arrow/compute/cast.h"
 #include "arrow/compute/exec.h"
 #include "arrow/compute/exec_internal.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/compute/registry.h"
 #include "arrow/compute/row/grouper.h"
 #include "arrow/table.h"

--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -68,7 +68,6 @@ using internal::ToChars;
 
 using compute::ArgShape;
 using compute::CallFunction;
-using compute::ComputeKernelEnvironment;
 using compute::CountOptions;
 using compute::default_exec_context;
 using compute::ExecBatchFromJSON;
@@ -87,10 +86,6 @@ using compute::Take;
 using compute::TDigestOptions;
 using compute::ValidateOutput;
 using compute::VarianceOptions;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 namespace acero {
 

--- a/cpp/src/arrow/acero/hash_join_node_test.cc
+++ b/cpp/src/arrow/acero/hash_join_node_test.cc
@@ -48,7 +48,6 @@ using arrow::random::kSeedMax;
 using arrow::random::RandomArrayGenerator;
 using compute::and_;
 using compute::call;
-using compute::ComputeKernelEnvironment;
 using compute::default_exec_context;
 using compute::ExecBatchBuilder;
 using compute::ExecBatchFromJSON;
@@ -58,10 +57,6 @@ using compute::SortIndices;
 using compute::SortKey;
 using compute::Take;
 using compute::internal::RowEncoder;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 namespace acero {
 

--- a/cpp/src/arrow/acero/hash_join_node_test.cc
+++ b/cpp/src/arrow/acero/hash_join_node_test.cc
@@ -26,7 +26,6 @@
 #include "arrow/acero/test_util_internal.h"
 #include "arrow/acero/util.h"
 #include "arrow/api.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/compute/light_array_internal.h"
 #include "arrow/compute/row/row_encoder_internal.h"
 #include "arrow/compute/test_util_internal.h"

--- a/cpp/src/arrow/acero/order_by_node_test.cc
+++ b/cpp/src/arrow/acero/order_by_node_test.cc
@@ -22,7 +22,6 @@
 #include "arrow/acero/exec_plan.h"
 #include "arrow/acero/options.h"
 #include "arrow/acero/test_nodes.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/table.h"
 #include "arrow/testing/generator.h"
 #include "arrow/testing/gtest_util.h"
@@ -35,10 +34,6 @@ using internal::checked_pointer_cast;
 
 using compute::SortKey;
 using compute::SortOrder;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 namespace acero {
 

--- a/cpp/src/arrow/acero/order_by_node_test.cc
+++ b/cpp/src/arrow/acero/order_by_node_test.cc
@@ -33,7 +33,6 @@ namespace arrow {
 
 using internal::checked_pointer_cast;
 
-using compute::ComputeKernelEnvironment;
 using compute::SortKey;
 using compute::SortOrder;
 

--- a/cpp/src/arrow/acero/plan_test.cc
+++ b/cpp/src/arrow/acero/plan_test.cc
@@ -27,7 +27,6 @@
 #include "arrow/acero/util.h"
 #include "arrow/compute/exec.h"
 #include "arrow/compute/expression.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/compute/test_util_internal.h"
 #include "arrow/io/util_internal.h"
 #include "arrow/record_batch.h"
@@ -55,7 +54,6 @@ namespace arrow {
 
 using compute::ArgShape;
 using compute::call;
-using compute::ComputeKernelEnvironment;
 using compute::CountOptions;
 using compute::ExecBatchFromJSON;
 using compute::field_ref;
@@ -64,10 +62,6 @@ using compute::SortKey;
 using compute::SortOrder;
 using compute::Take;
 using compute::TDigestOptions;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 namespace acero {
 

--- a/cpp/src/arrow/acero/test_util_internal_test.cc
+++ b/cpp/src/arrow/acero/test_util_internal_test.cc
@@ -18,14 +18,9 @@
 #include <gtest/gtest.h>
 
 #include "arrow/acero/test_util_internal.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/testing/gtest_util.h"
 
 namespace arrow::acero {
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new arrow::compute::ComputeKernelEnvironment);
 
 TEST(RunEndEncodeTableColumnsTest, SchemaTypeIsModified) {
   std::shared_ptr<Table> table =

--- a/cpp/src/arrow/c/CMakeLists.txt
+++ b/cpp/src/arrow/c/CMakeLists.txt
@@ -26,9 +26,9 @@ endif()
 
 if(ARROW_COMPUTE)
   if(ARROW_TEST_LINKAGE STREQUAL "static")
-    list(APPEND ARROW_TEST_LINK_LIBS arrow_compute_static)
+    list(APPEND ARROW_TEST_LINK_LIBS arrow_compute_static arrow_compute_testing)
   else()
-    list(APPEND ARROW_TEST_LINK_LIBS arrow_compute_shared)
+    list(APPEND ARROW_TEST_LINK_LIBS arrow_compute_shared arrow_compute_testing)
   endif()
 endif()
 

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -50,15 +50,9 @@
 // TODO(GH-37221): Remove these ifdef checks when compute dependency is removed
 #ifdef ARROW_COMPUTE
 #  include "arrow/compute/api_vector.h"
-#  include "arrow/compute/kernels/test_util_internal.h"
 #endif
 
 namespace arrow {
-#ifdef ARROW_COMPUTE
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new compute::ComputeKernelEnvironment);
-#endif
 using internal::ArrayDeviceExportTraits;
 using internal::ArrayDeviceStreamExportTraits;
 using internal::ArrayExportGuard;

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -134,7 +134,7 @@ add_arrow_compute_test(row_test
                        row/row_test.cc
                        util_internal_test.cc
                        EXTRA_LINK_LIBS
-                       arrow_compute_core_testing)
+                       arrow_compute_testing)
 
 add_arrow_benchmark(function_benchmark PREFIX "arrow-compute")
 

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -33,16 +33,23 @@ else()
   set(ARROW_COMPUTE_TEST_LINK_LIBS arrow_compute_shared ${ARROW_TEST_SHARED_LINK_LIBS})
 endif()
 
-# Define arrow_compute_testing object library for common test files
+# Define arrow_compute_core_testing object library for common test files requiring
+# only core compute. No extra kernels are required.
 if(ARROW_TESTING)
-  set(ARROW_COMPUTE_TESTING_SRCS test_util_internal.cc)
-  if(ARROW_COMPUTE)
-    list(APPEND ARROW_COMPUTE_TESTING_SRCS test_env.cc)
-  endif()
-  add_library(arrow_compute_testing OBJECT ${ARROW_COMPUTE_TESTING_SRCS})
+  add_library(arrow_compute_core_testing OBJECT test_util_internal.cc)
   # Even though this is still just an object library we still need to "link" our
   # dependencies so that include paths are configured correctly
-  target_link_libraries(arrow_compute_testing PUBLIC ${ARROW_GTEST_GMOCK})
+  target_link_libraries(arrow_compute_core_testing PUBLIC ${ARROW_GTEST_GMOCK})
+endif()
+
+# Define arrow_compute_testing object library for test files requiring extra kernels.
+if(ARROW_TESTING AND ARROW_COMPUTE)
+  set(ARROW_COMPUTE_TESTING_SRCS test_env.cc)
+  add_library(arrow_compute_testing OBJECT ${ARROW_COMPUTE_TESTING_SRCS})
+  # Even though this is still just an object library we still need to "link"
+  # arrow_compute_core_testing so that is also included correctly
+  target_link_libraries(arrow_compute_testing
+                        PUBLIC $<TARGET_OBJECTS:arrow_compute_core_testing>)
 endif()
 
 set(ARROW_COMPUTE_TEST_PREFIX "arrow-compute")
@@ -108,7 +115,7 @@ add_arrow_test(internals_test
                kernel_test.cc
                registry_test.cc
                EXTRA_LINK_LIBS
-               arrow_compute_testing)
+               arrow_compute_core_testing)
 
 add_arrow_compute_test(expression_test
                        SOURCES
@@ -126,7 +133,7 @@ add_arrow_compute_test(row_test
                        row/row_test.cc
                        util_internal_test.cc
                        EXTRA_LINK_LIBS
-                       arrow_compute_testing)
+                       arrow_compute_core_testing)
 
 add_arrow_benchmark(function_benchmark PREFIX "arrow-compute")
 

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -49,7 +49,8 @@ if(ARROW_TESTING AND ARROW_COMPUTE)
   # Even though this is still just an object library we still need to "link"
   # arrow_compute_core_testing so that is also included correctly
   target_link_libraries(arrow_compute_testing
-                        PUBLIC $<TARGET_OBJECTS:arrow_compute_core_testing>)
+                        PUBLIC $<TARGET_OBJECTS:arrow_compute_core_testing>
+                        PUBLIC ${ARROW_GTEST_GTEST_MAIN})
 endif()
 
 set(ARROW_COMPUTE_TEST_PREFIX "arrow-compute")

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -35,7 +35,11 @@ endif()
 
 # Define arrow_compute_testing object library for common test files
 if(ARROW_TESTING)
-  add_library(arrow_compute_testing OBJECT test_util_internal.cc)
+  set(ARROW_COMPUTE_TESTING_SRCS test_util_internal.cc)
+  if(ARROW_COMPUTE)
+    list(APPEND ARROW_COMPUTE_TESTING_SRCS test_env.cc)
+  endif()
+  add_library(arrow_compute_testing OBJECT ${ARROW_COMPUTE_TESTING_SRCS})
   # Even though this is still just an object library we still need to "link" our
   # dependencies so that include paths are configured correctly
   target_link_libraries(arrow_compute_testing PUBLIC ${ARROW_GTEST_GMOCK})

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -30,7 +30,6 @@
 #include "arrow/array/builder_primitive.h"
 #include "arrow/compute/expression_internal.h"
 #include "arrow/compute/function_internal.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/compute/registry.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/matchers.h"
@@ -47,10 +46,6 @@ using internal::checked_cast;
 using internal::checked_pointer_cast;
 
 namespace compute {
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 const std::shared_ptr<Schema> kBoringSchema = schema({
     field("bool", boolean()),

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -34,7 +34,7 @@ add_arrow_test(scalar_cast_test
                scalar_cast_test.cc
                EXTRA_LINK_LIBS
                arrow_compute_kernels_testing
-               arrow_compute_testing)
+               arrow_compute_core_testing)
 
 # ----------------------------------------------------------------------
 # Scalar kernels

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -32,6 +32,7 @@
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/cast.h"
 #include "arrow/compute/kernels/aggregate_internal.h"
+#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/compute/registry.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -32,7 +32,6 @@
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/cast.h"
 #include "arrow/compute/kernels/aggregate_internal.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/compute/registry.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
@@ -55,10 +54,6 @@ using internal::checked_pointer_cast;
 namespace compute {
 
 using internal::FindAccumulatorType;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 //
 // Sum

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -45,10 +45,6 @@
 namespace arrow {
 namespace compute {
 
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
-
 namespace {
 
 // 2.718281828459045090795598298427648842334747314453125

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -44,7 +44,6 @@
 
 namespace arrow {
 namespace compute {
-
 namespace {
 
 // 2.718281828459045090795598298427648842334747314453125

--- a/cpp/src/arrow/compute/kernels/scalar_boolean_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_boolean_test.cc
@@ -34,10 +34,6 @@ using internal::checked_pointer_cast;
 
 namespace compute {
 
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
-
 void CheckBooleanScalarArrayBinary(std::string func_name, Datum array) {
   for (std::shared_ptr<Scalar> scalar :
        {std::make_shared<BooleanScalar>(), std::make_shared<BooleanScalar>(true),

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -34,10 +34,6 @@ using internal::checked_pointer_cast;
 
 namespace compute {
 
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
-
 // Helper that combines a dictionary and the value type so it can
 // later be used with DictArrayFromJSON
 struct JsonDict {

--- a/cpp/src/arrow/compute/kernels/scalar_random_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_random_test.cc
@@ -28,10 +28,6 @@ using internal::ThreadPool;
 
 namespace compute {
 
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
-
 namespace {
 
 void TestRandomWithOptions(int64_t length, const RandomOptions& random_options) {

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -38,10 +38,6 @@ using internal::StringFormatter;
 
 namespace compute {
 
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
-
 class ScalarTemporalTest : public ::testing::Test {
  public:
   const char* date32s =

--- a/cpp/src/arrow/compute/kernels/test_util_internal.h
+++ b/cpp/src/arrow/compute/kernels/test_util_internal.h
@@ -28,7 +28,6 @@
 #include "arrow/array.h"
 #include "arrow/compute/api_scalar.h"
 #include "arrow/compute/cast.h"
-#include "arrow/compute/initialize.h"
 #include "arrow/compute/kernel.h"
 #include "arrow/compute/test_util_internal.h"
 #include "arrow/datum.h"
@@ -50,15 +49,6 @@ using internal::checked_cast;
 namespace compute {
 
 using DatumVector = std::vector<Datum>;
-
-class ComputeKernelEnvironment : public ::testing::Environment {
- public:
-  // This must be done before using the compute kernels in order to
-  // register them to the FunctionRegistry.
-  ComputeKernelEnvironment() : ::testing::Environment() {}
-
-  void SetUp() override { ASSERT_OK(arrow::compute::Initialize()); }
-};
 
 template <typename Type, typename T>
 std::shared_ptr<Array> _MakeArray(const std::shared_ptr<DataType>& type,

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops_test.cc
@@ -37,10 +37,6 @@
 namespace arrow {
 namespace compute {
 
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
-
 static const std::vector<std::string> kCumulativeFunctionNames{
     "cumulative_sum",          "cumulative_sum_checked", "cumulative_prod",
     "cumulative_prod_checked", "cumulative_min",         "cumulative_max",

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -45,10 +45,6 @@ using std::string_view;
 
 namespace compute {
 
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
-
 namespace {
 
 template <typename T>

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -46,10 +46,6 @@ using internal::checked_pointer_cast;
 
 namespace compute {
 
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
-
 #ifdef ARROW_VALGRIND
 using RealArrowTypes = ::testing::Types<FloatType>;
 

--- a/cpp/src/arrow/compute/kernels/vector_swizzle_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_swizzle_test.cc
@@ -28,10 +28,6 @@
 
 namespace arrow::compute {
 
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
-
 namespace {
 
 using SmallSignedIntegerTypes = ::testing::Types<Int8Type, Int16Type>;

--- a/cpp/src/arrow/compute/test_env.cc
+++ b/cpp/src/arrow/compute/test_env.cc
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+
+#include "arrow/compute/initialize.h"
+#include "arrow/testing/gtest_util.h"
+
+namespace arrow::compute {
+
+namespace {
+
+class ComputeKernelEnvironment : public ::testing::Environment {
+ public:
+  // This must be done before using the compute kernels in order to
+  // register them to the FunctionRegistry.
+  ComputeKernelEnvironment() : ::testing::Environment() {}
+
+  void SetUp() override { ASSERT_OK(arrow::compute::Initialize()); }
+};
+
+}  // namespace
+
+// Initialize the compute module
+::testing::Environment* compute_kernels_env =
+    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
+
+}  // namespace arrow::compute

--- a/cpp/src/arrow/compute/test_env.cc
+++ b/cpp/src/arrow/compute/test_env.cc
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #include <gtest/gtest.h>
 
 #include "arrow/compute/initialize.h"

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -19,7 +19,6 @@
 
 #include <optional>
 
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/discovery.h"
 #include "arrow/dataset/partition.h"
@@ -30,12 +29,6 @@
 #include "arrow/testing/generator.h"
 
 namespace arrow {
-
-using compute::ComputeKernelEnvironment;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 namespace dataset {
 

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -29,7 +29,6 @@
 #include "arrow/testing/generator.h"
 
 namespace arrow {
-
 namespace dataset {
 
 class TestInMemoryFragment : public DatasetFixtureMixin {};

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -23,7 +23,6 @@
 #include <memory>
 #include <utility>
 
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/dataset/partition.h"
 #include "arrow/dataset/test_util_internal.h"
 #include "arrow/filesystem/test_util.h"
@@ -35,11 +34,6 @@ using testing::SizeIs;
 
 namespace arrow {
 
-using compute::ComputeKernelEnvironment;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 namespace dataset {
 
 void AssertSchemasAre(std::vector<std::shared_ptr<Schema>> actual,

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -33,7 +33,6 @@
 using testing::SizeIs;
 
 namespace arrow {
-
 namespace dataset {
 
 void AssertSchemasAre(std::vector<std::shared_ptr<Schema>> actual,

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include "arrow/acero/exec_plan.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/csv/writer.h"
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/file_base.h"
@@ -40,11 +39,6 @@
 #include "arrow/util/config.h"
 
 namespace arrow {
-using compute::ComputeKernelEnvironment;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 namespace dataset {
 
 class CsvFormatHelper {

--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -21,7 +21,6 @@
 #include <utility>
 #include <vector>
 
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/discovery.h"
 #include "arrow/dataset/file_base.h"
@@ -38,12 +37,7 @@
 
 namespace arrow {
 
-using compute::ComputeKernelEnvironment;
 using internal::checked_pointer_cast;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 namespace dataset {
 

--- a/cpp/src/arrow/dataset/file_json_test.cc
+++ b/cpp/src/arrow/dataset/file_json_test.cc
@@ -17,7 +17,6 @@
 
 #include "arrow/dataset/file_json.h"
 
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/dataset/plan.h"
 #include "arrow/dataset/test_util_internal.h"
 #include "arrow/filesystem/mockfs.h"
@@ -33,12 +32,6 @@
 namespace arrow {
 
 using internal::checked_cast;
-
-using compute::ComputeKernelEnvironment;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 namespace dataset {
 

--- a/cpp/src/arrow/dataset/file_orc_test.cc
+++ b/cpp/src/arrow/dataset/file_orc_test.cc
@@ -21,7 +21,6 @@
 #include <utility>
 
 #include "arrow/adapters/orc/adapter.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/discovery.h"
 #include "arrow/dataset/file_base.h"
@@ -34,11 +33,6 @@
 #include "arrow/testing/util.h"
 
 namespace arrow {
-using compute::ComputeKernelEnvironment;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 namespace dataset {
 
 class OrcFormatHelper {

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -21,7 +21,6 @@
 
 #include "arrow/array.h"
 #include "arrow/compute/api_vector.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/dataset/dataset.h"
 #include "arrow/dataset/file_base.h"
 #include "arrow/dataset/file_parquet.h"
@@ -53,12 +52,6 @@ constexpr std::string_view kBaseDir = "";
 using arrow::internal::checked_pointer_cast;
 
 namespace arrow {
-
-using compute::ComputeKernelEnvironment;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 namespace dataset {
 

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -52,7 +52,6 @@ constexpr std::string_view kBaseDir = "";
 using arrow::internal::checked_pointer_cast;
 
 namespace arrow {
-
 namespace dataset {
 
 struct EncryptionTestParam {

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -23,7 +23,6 @@
 #include <vector>
 
 #include "arrow/compute/api_scalar.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/parquet_encryption_config.h"
 #include "arrow/dataset/test_util_internal.h"
@@ -49,11 +48,6 @@
 
 namespace arrow {
 
-using compute::ComputeKernelEnvironment;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 using internal::checked_cast;
 using internal::checked_pointer_cast;
 

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -34,7 +34,6 @@
 #include "arrow/acero/exec_plan.h"
 #include "arrow/acero/test_util_internal.h"
 #include "arrow/array/array_primitive.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/compute/test_util_internal.h"
 #include "arrow/dataset/api.h"
 #include "arrow/dataset/partition.h"
@@ -51,11 +50,6 @@
 namespace cp = arrow::compute;
 
 namespace arrow {
-using compute::ComputeKernelEnvironment;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 using compute::ExecBatchFromJSON;
 using internal::TemporaryDir;

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -29,7 +29,6 @@
 #include "arrow/compute/api_scalar.h"
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/cast.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/dataset/dataset.h"
 #include "arrow/dataset/file_ipc.h"
 #include "arrow/dataset/test_util_internal.h"
@@ -41,11 +40,6 @@
 #include "arrow/util/uri.h"
 
 namespace arrow {
-using compute::ComputeKernelEnvironment;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 using compute::Cast;
 

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -30,7 +30,6 @@
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/cast.h"
 #include "arrow/compute/expression_internal.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/plan.h"
 #include "arrow/dataset/test_util_internal.h"
@@ -56,13 +55,8 @@ using testing::UnorderedElementsAreArray;
 
 namespace arrow {
 
-using compute::ComputeKernelEnvironment;
 using internal::GetCpuThreadPool;
 using internal::Iota;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 namespace dataset {
 

--- a/cpp/src/arrow/engine/CMakeLists.txt
+++ b/cpp/src/arrow/engine/CMakeLists.txt
@@ -87,6 +87,7 @@ add_arrow_test(substrait_test
                substrait/test_util.cc
                EXTRA_LINK_LIBS
                ${ARROW_SUBSTRAIT_TEST_LINK_LIBS}
+               arrow_compute_testing
                PREFIX
                "arrow-substrait"
                LABELS

--- a/cpp/src/arrow/engine/substrait/function_test.cc
+++ b/cpp/src/arrow/engine/substrait/function_test.cc
@@ -34,7 +34,6 @@
 #include "arrow/array/builder_binary.h"
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/cast.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/datum.h"
 #include "arrow/engine/substrait/extension_set.h"
 #include "arrow/engine/substrait/options.h"
@@ -49,11 +48,6 @@
 #include "arrow/type_fwd.h"
 
 namespace arrow {
-using compute::ComputeKernelEnvironment;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 namespace engine {
 struct FunctionTestCase {

--- a/cpp/src/arrow/flight/sql/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/CMakeLists.txt
@@ -119,6 +119,7 @@ if(ARROW_BUILD_TESTS OR ARROW_BUILD_EXAMPLES)
 
   set(ARROW_FLIGHT_SQL_TEST_LIBS ${SQLite3_LIBRARIES})
   set(ARROW_FLIGHT_SQL_ACERO_SRCS example/acero_server.cc)
+  set(ARROW_FLIGHT_SQL_EXTRA_LINK_LIBS "")
 
   if(ARROW_COMPUTE
      AND ARROW_PARQUET
@@ -129,6 +130,7 @@ if(ARROW_BUILD_TESTS OR ARROW_BUILD_EXAMPLES)
     else()
       list(APPEND ARROW_FLIGHT_SQL_TEST_LIBS arrow_substrait_shared)
     endif()
+    list(APPEND ARROW_FLIGHT_SQL_EXTRA_LINK_LIBS arrow_compute_testing)
 
     if(ARROW_BUILD_EXAMPLES)
       add_executable(acero-flight-sql-server ${ARROW_FLIGHT_SQL_ACERO_SRCS}
@@ -146,6 +148,8 @@ if(ARROW_BUILD_TESTS OR ARROW_BUILD_EXAMPLES)
                  STATIC_LINK_LIBS
                  ${ARROW_FLIGHT_SQL_TEST_LINK_LIBS}
                  ${ARROW_FLIGHT_SQL_TEST_LIBS}
+                 EXTRA_LINK_LIBS
+                 ${ARROW_FLIGHT_SQL_EXTRA_LINK_LIBS}
                  EXTRA_INCLUDES
                  "${CMAKE_CURRENT_BINARY_DIR}/../"
                  LABELS

--- a/cpp/src/arrow/flight/sql/acero_test.cc
+++ b/cpp/src/arrow/flight/sql/acero_test.cc
@@ -24,7 +24,6 @@
 #include <gtest/gtest.h>
 
 #include "arrow/array.h"
-#include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/engine/substrait/util.h"
 #include "arrow/flight/server.h"
 #include "arrow/flight/sql/client.h"
@@ -39,11 +38,6 @@
 #include "arrow/util/checked_cast.h"
 
 namespace arrow {
-using compute::ComputeKernelEnvironment;
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 namespace flight {
 namespace sql {
 


### PR DESCRIPTION
Introduce a common obj file containing the global test env registration. Include it into `arrow_compute_testing` so that every test executable depending on `arrow_compute_testing` automatically registers the test env. This way, no test need to explicitly do the registration and a lot of code can be reverted.